### PR TITLE
fix: allow ignoring the footnotes

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -14,6 +14,7 @@ const program = new Command()
   .option('-p, --preset [name]', `Preset config(eg ${Object.keys(presetConfig).join(', ')})`)
   .option('-P, --pattern [pattern]', `Glob patterns, default to ${presetConfig.default.pattern}`)
   .option('-i, --ignore [pattern]', `Ignore patterns, will merge to pattern, default to ${presetConfig.default.ignore.join(',')}`)
+  .option('--ignore-footnotes', `Ignore footnotes, default to ${presetConfig.default.ignoreFootnotes}`)
   .option('--exit-level [level]', `Process exit level, default to ${presetConfig.default.exitLevel}, other choice is warn and none, it will not exit if setting to none`)
   .option('--default-index [index]', `Default index in directory, default to ${presetConfig.default.defaultIndex.join(',')}`);
 
@@ -26,6 +27,7 @@ const options = {
   exitLevel: program.exitLevel,
   pattern: program.pattern ? program.pattern.split(',') : undefined,
   ignore: program.ignore ? program.ignore.split(',') : undefined,
+  ignoreFootnotes: false,
   defaultIndex: program.defaultIndex ? program.defaultIndex.split(',') : undefined,
 };
 

--- a/bin.js
+++ b/bin.js
@@ -27,7 +27,7 @@ const options = {
   exitLevel: program.exitLevel,
   pattern: program.pattern ? program.pattern.split(',') : undefined,
   ignore: program.ignore ? program.ignore.split(',') : undefined,
-  ignoreFootnotes: false,
+  ignoreFootnotes: program.ignoreFootnotes,
   defaultIndex: program.defaultIndex ? program.defaultIndex.split(',') : undefined,
 };
 

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ const presetConfig = {
     root: [ './' ],
     pattern: '**/*.md',
     ignore: [ '**/node_modules' ],
+    ignoreFootnotes: false,
     cwd: process.cwd(),
     exitLevel: 'error',
     slugify: defaultSlugify,
@@ -58,6 +59,7 @@ const presetConfig = {
  * @property {String} [CheckOption.preset]
  * @property {String | Array<String>} [CheckOption.pattern]
  * @property {String | Array<String>} [CheckOption.ignore]
+ * @property {Boolean} [CheckOption.ignoreFootnotes]
  */
 
 /**
@@ -217,7 +219,7 @@ function initOption(options) {
  */
 async function check(options) {
   options = initOption(options);
-  const { cwd, defaultIndex, root, fix, pattern, ignore } = options;
+  const { cwd, defaultIndex, root, fix, pattern, ignore, ignoreFootnotes } = options;
   assert(Array.isArray(root), 'options.root must be array');
   const globPattern = (Array.isArray(pattern) ? pattern : [ pattern ]).concat(
     (Array.isArray(ignore) ? ignore : [ ignore ]).map(p => `!${p}`)
@@ -287,6 +289,8 @@ async function check(options) {
         const urlObj = url.parse(matchUrl);
         if (urlObj.protocol) {
           // do nothing with remote url
+        } else if (ignoreFootnotes && char.startsWith('[^')) {
+          // do nothing with footnote
         } else if (!matchUrl) {
           // empty url
           result.deadlink.list.push({ ...baseReportObj, errMsg: 'Url link is empty' });

--- a/test/fixtures/docs1/test.md
+++ b/test/fixtures/docs1/test.md
@@ -37,3 +37,7 @@ aaa
 asdasd11123 ```[test15](./123.md#ctx.get(name))```
 
 [test16](./123.md#ctx.get(name))
+
+Footnotes[^test17] test ref
+
+[^test17]: Footnote description

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,7 +9,7 @@ describe('test/index.test.js', () => {
 
   it('should works without error', async () => {
     const result = await checkMd.check({ cwd: path.resolve(__dirname, './fixtures/docs1') });
-    assert(result.deadlink.list.length === 5);
+    assert(result.deadlink.list.length === 6);
     assert(result.warning.list.length === 1);
     assert(result.deadlink.list[0].fullText.includes('[test1]'));
     assert(result.deadlink.list[0].line === 5);
@@ -23,7 +23,16 @@ describe('test/index.test.js', () => {
     assert(result.deadlink.list[3].fullText.includes('[test12]'));
     assert(result.deadlink.list[4].fullText.includes('[test16]'));
     assert(result.deadlink.list[3].errMsg.includes('slugify'));
+    assert(result.deadlink.list[5].fullText.includes('[^test17]'));
+    assert(result.deadlink.list[5].line === 43);
+    assert(result.deadlink.list[5].col === 1);
     assert(result.warning.list[0].fullText.includes('[test6]'));
+
+    const resultWithIgnoreFootnotes = await checkMd.check({
+      cwd: path.resolve(__dirname, './fixtures/docs1'),
+      ignoreFootnotes: true,
+    });
+    assert(resultWithIgnoreFootnotes.deadlink.list.length === 5);
   });
 
   it('should fix without error', async () => {


### PR DESCRIPTION
Currently, the footnotes are seen as broken links. this PR adds a new option to ignore footnotes links and thus enable retro-compatibility with the previous API.

▫️ Creates new option to the command line
▫️ Sets option default value to false
▫️ Implements behavior
▫️ Test: Adds new lines to docs1/test.md
▫️ Test: Extends with 3 assertions
▫️ Test: Increments dead links from 5 to 6