### PR TITLE
Add --ignore-paths option

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -14,6 +14,7 @@ const program = new Command()
   .option('-p, --preset [name]', `Preset config(eg ${Object.keys(presetConfig).join(', ')})`)
   .option('-P, --pattern [pattern]', `Glob patterns, default to ${presetConfig.default.pattern}`)
   .option('-i, --ignore [pattern]', `Ignore patterns, will merge to pattern, default to ${presetConfig.default.ignore.join(',')}`)
+  .option('--ignore-path [path]', 'Ignore path(s) from lookup')
   .option('--ignore-footnotes', `Ignore footnotes, default to ${presetConfig.default.ignoreFootnotes}`)
   .option('--exit-level [level]', `Process exit level, default to ${presetConfig.default.exitLevel}, other choice is warn and none, it will not exit if setting to none`)
   .option('--default-index [index]', `Default index in directory, default to ${presetConfig.default.defaultIndex.join(',')}`);
@@ -28,6 +29,7 @@ const options = {
   pattern: program.pattern ? program.pattern.split(',') : undefined,
   ignore: program.ignore ? program.ignore.split(',') : undefined,
   ignoreFootnotes: program.ignoreFootnotes,
+  ignorePaths: program.ignorePath ? program.ignorePath.split(',') : undefined,
   defaultIndex: program.defaultIndex ? program.defaultIndex.split(',') : undefined,
 };
 

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ const presetConfig = {
     pattern: '**/*.md',
     ignore: [ '**/node_modules' ],
     ignoreFootnotes: false,
+    ignorePaths: [],
     cwd: process.cwd(),
     exitLevel: 'error',
     slugify: defaultSlugify,
@@ -219,7 +220,7 @@ function initOption(options) {
  */
 async function check(options) {
   options = initOption(options);
-  const { cwd, defaultIndex, root, fix, pattern, ignore, ignoreFootnotes } = options;
+  const { cwd, defaultIndex, root, fix, pattern, ignore, ignoreFootnotes, ignorePaths } = options;
   assert(Array.isArray(root), 'options.root must be array');
   const globPattern = (Array.isArray(pattern) ? pattern : [ pattern ]).concat(
     (Array.isArray(ignore) ? ignore : [ ignore ]).map(p => `!${p}`)
@@ -300,7 +301,7 @@ async function check(options) {
           let ext = path.extname(pathname);
           let matchAbUrl;
 
-          if (pathname) {
+          if (pathname && !ignorePaths.includes(pathname)) {
             if (pathname.charAt(0) === '/') {
               // find exist file
               matchAbUrl = root.map(r => normalizeUrl(path.join(cwd, r, pathname.substring(1)), ext))


### PR DESCRIPTION
This can be used to disable the validation on some paths. 

Example use case are auto-generated paths in a VuePress site which do not exist as markdown file but may be linked to.

I am not entirely happy with this. Ideally, having a path ignored should - in my opinion - exit out of that links' evaluation. Unfortunately, the only way I see to implement this would be to wrap the whole evaluation step in a `try-catch` and `throw` out if `ignorePaths.includes(pathname)`. Instead of doing that, I would much rather untangle the beast the `if`-chain is becoming. That is a discussion to be had separately (or started here and moved to a separate PR?)

Another thing with change: Things won't work with attached fragments. This goes back to the above issue of the continued evaluation. I'm sure there's a condition in there which can be slightly modified to catch ignored paths with fragments too, but I failed to identify it. 🙁 

Anyway, thanks for this awesome tool, it's a huge time saver. ❤️ 