### PR TITLE
De-duplicating slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,18 @@ $ npx check-md
 Usage: check-md [options]
 
 Options:
-  -v, --version            output the version number
-  -f, --fix                Check and try to fix
-  -c, --cwd [path]         Working directory of check-md, default to process.cwd()
-  -r, --root [path]        Checking url root, default to ./
-  -p, --preset [name]      Preset config(eg vuepress, default)
-  -P, --pattern [pattern]  Glob patterns, default to **/*.md
-  -i, --ignore [pattern]   Ignore patterns, will merge to pattern, default to **/node_modules
-  --exit-level [level]     Process exit level, default to error, other choice is warn and none, it will not exit if setting to none
-  --default-index [index]  Default index in directory, default to README.md,readme.md
-  -h, --help               output usage information
+  -v, --version                       output the version number
+  -f, --fix                           Check and try to fix
+  -c, --cwd [path]                    Working directory of check-md, default to process.cwd()
+  -r, --root [path]                   Checking url root, default to ./
+  -p, --preset [name]                 Preset config(eg vuepress, default)
+  -P, --pattern [pattern]             Glob patterns, default to **/*.md
+  -i, --ignore [pattern]              Ignore patterns, will merge to pattern, default to **/node_modules
+  --ignore-footnotes                  Ignore footnotes, default to false
+  --unique-slug-start-index [number]  Index to start with when making duplicate slugs unique, default to 2
+  --exit-level [level]                Process exit level, default to error, other choice is warn and none, it will not exit if setting to none
+  --default-index [index]             Default index in directory, default to README.md,readme.md
+  -h, --help                          output usage information
 ```
 
 configure in `package.json`
@@ -54,7 +56,7 @@ configure in `package.json`
   "check-md": {
     "cwd": "./",
     "defaultIndex": [ "index.md" ],
-    "exitLevel": "warn",
+    "exitLevel": "warn"
   }
 }
 ```

--- a/bin.js
+++ b/bin.js
@@ -15,6 +15,7 @@ const program = new Command()
   .option('-P, --pattern [pattern]', `Glob patterns, default to ${presetConfig.default.pattern}`)
   .option('-i, --ignore [pattern]', `Ignore patterns, will merge to pattern, default to ${presetConfig.default.ignore.join(',')}`)
   .option('--ignore-footnotes', `Ignore footnotes, default to ${presetConfig.default.ignoreFootnotes}`)
+  .option('--unique-slug-start-index [number]', `Index to start with when making duplicate slugs unique, default to ${presetConfig.default.uniqueSlugStartIndex}`)
   .option('--exit-level [level]', `Process exit level, default to ${presetConfig.default.exitLevel}, other choice is warn and none, it will not exit if setting to none`)
   .option('--default-index [index]', `Default index in directory, default to ${presetConfig.default.defaultIndex.join(',')}`);
 
@@ -28,6 +29,7 @@ const options = {
   pattern: program.pattern ? program.pattern.split(',') : undefined,
   ignore: program.ignore ? program.ignore.split(',') : undefined,
   ignoreFootnotes: program.ignoreFootnotes,
+  uniqueSlugStartIndex: program.uniqueSlugStartIndex,
   defaultIndex: program.defaultIndex ? program.defaultIndex.split(',') : undefined,
 };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,8 @@ export interface CheckOption {
   preset?: string;
   pattern?: string | string[];
   ignore?: string | string[];
+  uniqueSlugStartIndex?: number;
+  ignoreFootnotes?: boolean;
 }
 export interface ReportListItem {
   errMsg: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,18 @@
-// Generate by [js2dts](https://github.com/whxaxes/js2dts#readme)
+// Generate by [js2dts@0.3.3](https://github.com/whxaxes/js2dts#readme)
 
+declare function defaultSlugify(str: any, lower?: boolean): any;
 export interface CheckOption {
   cwd: string;
   fix?: boolean;
-  exitLevel?: "none" | "info" | "warn" | "error";
+  exitLevel?: "warn" | "none" | "info" | "error";
   root?: string[];
   defaultIndex?: string[];
   preset?: string;
   pattern?: string | string[];
   ignore?: string | string[];
-  uniqueSlugStartIndex?: number;
   ignoreFootnotes?: boolean;
+  uniqueSlugStartIndex?: number;
+  slugify?: typeof defaultSlugify;
 }
 export interface ReportListItem {
   errMsg: string;
@@ -23,7 +25,7 @@ export interface ReportListItem {
 export interface ReportResult {
   msg: string;
   list: ReportListItem[];
-  type: "none" | "info" | "warn" | "error";
+  type: "warn" | "none" | "info" | "error";
 }
 export interface T100 {
   warning: ReportResult;
@@ -31,18 +33,19 @@ export interface T100 {
 }
 /**
  * check markdown
- * @param {CheckOption} options
+ * @param {CheckOption} options - options
  */
 declare function check_1(options: CheckOption): Promise<T100>;
 export const check: typeof check_1;
 /**
  * check and throw
- * @param {CheckOption} options
+ * @param {CheckOption} options - options
  */
 declare function checkAndThrow_1(options: CheckOption): Promise<void>;
 export const checkAndThrow: typeof checkAndThrow_1;
 export interface T101 {
   root: string[];
+  slugify: typeof defaultSlugify;
   cwd: string;
 }
 export interface T102 {
@@ -50,8 +53,11 @@ export interface T102 {
   root: string[];
   pattern: string;
   ignore: string[];
+  ignoreFootnotes: boolean;
+  uniqueSlugStartIndex: number;
   cwd: string;
   exitLevel: string;
+  slugify: typeof defaultSlugify;
 }
 export interface T103 {
   vuepress: T101;
@@ -60,8 +66,8 @@ export interface T103 {
 export const presetConfig: T103;
 /**
  * set content with cache
- * @param {String} fileUrl
- * @param {String} content
+ * @param {String} fileUrl - fileUrl
+ * @param {String} content - content
  */
 declare function setContent_1(fileUrl: string, content: string): void;
 export const setContent: typeof setContent_1;
@@ -73,8 +79,8 @@ export interface CacheObj {
 }
 /**
  * get content with cache
- * @param {String} fileUrl
- * @return {CacheObj}
+ * @param {String} fileUrl - fileUrl
+ * @return {CacheObj} - CacheObj
  */
 declare function getContent_1(fileUrl: string): CacheObj;
 export const getContent: typeof getContent_1;

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ const presetConfig = {
  * @property {String | Array<String>} [CheckOption.ignore]
  * @property {Boolean} [CheckOption.ignoreFootnotes]
  * @property {Number} [CheckOption.uniqueSlugStartIndex]
+ * @property {typeof defaultSlugify} [CheckOption.slugify]
  */
 
 /**

--- a/index.js
+++ b/index.js
@@ -93,7 +93,13 @@ function hasHeading(fileUrl, heading, slugify) {
   if (!cacheObj.headings) {
     cacheObj.headings = [];
     cacheObj.content.replace(headingRE, (_, hash) => {
-      cacheObj.headings.push(slugify(hash.trim()));
+      let i = 2;
+      let slug = slugify(hash.trim());
+      while (cacheObj.headings.includes(slug)) {
+        slug = `${slug}-${i}`;
+        i++;
+      }
+      cacheObj.headings.push(slug);
     });
   }
 

--- a/test/fixtures/docs1/other.md
+++ b/test/fixtures/docs1/other.md
@@ -8,3 +8,5 @@ test
 ##testOther
 
 ##testOther
+
+##testOther

--- a/test/fixtures/docs1/other.md
+++ b/test/fixtures/docs1/other.md
@@ -6,3 +6,5 @@ test
 ## 测试中文
 
 ##testOther
+
+##testOther

--- a/test/fixtures/docs1/test.md
+++ b/test/fixtures/docs1/test.md
@@ -50,4 +50,6 @@ Footnotes[^test17] test ref
 
 ![test21](./dir/not-exist.png =100x100)
 
-[test22](./other#testother-2)
+[test22](./other#testother-1)
+
+[test23](./other#testother-2)

--- a/test/fixtures/docs1/test.md
+++ b/test/fixtures/docs1/test.md
@@ -49,3 +49,5 @@ Footnotes[^test17] test ref
 ![test20](./dir/not-exist.png =200x)
 
 ![test21](./dir/not-exist.png =100x100)
+
+[test22](./other#testother-2)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,7 +9,7 @@ describe('test/index.test.js', () => {
 
   it('should works without error', async () => {
     const result = await checkMd.check({ cwd: path.resolve(__dirname, './fixtures/docs1') });
-    assert(result.deadlink.list.length === 9);
+    assert(result.deadlink.list.length === 10);
     assert(result.warning.list.length === 1);
     assert(result.deadlink.list[0].fullText.includes('[test1]'));
     assert(result.deadlink.list[0].line === 5);
@@ -27,13 +27,22 @@ describe('test/index.test.js', () => {
     assert(result.deadlink.list[5].line === 43);
     assert(result.deadlink.list[5].col === 1);
     assert(result.deadlink.list[6].fullText.includes('![test19]'));
+    assert(result.deadlink.list[9].fullText.includes('[test22]'));
+    assert(result.deadlink.list[9].line === 53);
+    assert(result.deadlink.list[9].col === 1);
     assert(result.warning.list[0].fullText.includes('[test6]'));
 
     const resultWithIgnoreFootnotes = await checkMd.check({
       cwd: path.resolve(__dirname, './fixtures/docs1'),
       ignoreFootnotes: true,
     });
-    assert(resultWithIgnoreFootnotes.deadlink.list.length === 8);
+    assert(resultWithIgnoreFootnotes.deadlink.list.length === 9);
+
+    const resultWithUniqueSlugStartIndex = await checkMd.check({
+      cwd: path.resolve(__dirname, './fixtures/docs1'),
+      uniqueSlugStartIndex: 1,
+    });
+    assert(resultWithUniqueSlugStartIndex.deadlink.list.length === 9);
   });
 
   it('should fix without error', async () => {


### PR DESCRIPTION
Hello,

This is a PR that de-duplicates the slugs assigned as hashes of headers, if there are multiple headers with the same title in the same file, as is done by https://github.com/valeriangalliat/markdown-it-anchor and most markdown to HTML converters.

For example, if there are two `### Example` headers in the file `file.md`, the first header gets assigned `file.md#example`, and the second one gets `file.md#example-2` (for `markdown-it-anchor` < 6, which VuePress still uses) or `file.md#example-1` (for `markdown-it-anchor` >= 6, as well as markdown-toc, github-slugger, and GitHub).

Currently, `check-md` wrongly considers these `-n` anchors as broken. This PR fixes it.

The behaviour is configurable with the introduced `uniqueSlugStartIndex` option.

I took the liberty of setting the default for `uniqueSlugStartIndex` at `2`, like VuePress, but of course this could be changed to only be 2 with the VuePress preset, and 1 otherwise.

I also had to clear the content caches between runs of the `.check` function, because the cache content depends on the options passed to it, so the tests of the `uniqueSlugStartIndex` option would not work without clearing it.

Lastly, I updated `README.md` and `index.d.ts` files to reflect my changes, and the `ignoreFootnotes` change (they had not been updated for it).
